### PR TITLE
Babric Sprint Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,10 @@ dependencies {
     modImplementation("net.glasslauncher.mods:AlwaysMoreItems:${project.alwaysmoreitems_version}") {
         transitive false
     }
+
+    modImplementation("com.github.matthewperiut:babric-sprint:${project.babricsprint_version}") {
+        transitive false
+    }
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.daemon=false
 	loader_version=0.15.6-babric.1
 
 # Mod Properties
-	mod_version=0.14.4
+	mod_version=0.14.5
 	maven_group=net.danygames2014
 	archives_base_name=UniTweaks
 
@@ -21,3 +21,4 @@ org.gradle.daemon=false
 	gcapi_version=3.0.0
 	alwaysmoreitems_version=1.0.3
 	modmenu_version=1.8.5-beta.9
+	babricsprint_version = 1.0.0

--- a/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/fov/class555Mixin.java
+++ b/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/fov/class555Mixin.java
@@ -3,6 +3,7 @@ package net.danygames2014.unitweaks.mixin.tweaks.fov;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.danygames2014.unitweaks.tweaks.morekeybinds.KeyBindingListener;
 import net.danygames2014.unitweaks.util.ModOptions;
+import net.danygames2014.unitweaks.util.compat.SprintHelper;
 import net.minecraft.block.material.Material;
 import net.minecraft.class_555;
 import net.minecraft.client.Minecraft;
@@ -19,6 +20,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.danygames2014.unitweaks.util.compat.CompatEntry.sprint;
 
 @Mixin(class_555.class)
 public class class555Mixin {
@@ -69,9 +72,6 @@ public class class555Mixin {
             }
 
             fov += fovZoom;
-
-//            System.out.println("isHand = " + isHand + " | fov = " + fov + " | fovZoom = " + fovZoom + " | 5f-fov = " + (5f - fov) + " | 130f-fov = " + (130f - fov));
-
         } else {
             zoomedIn = false;
         }
@@ -79,6 +79,10 @@ public class class555Mixin {
         if (entity.health <= 0) {
             float deathTimeFov = (float) entity.deathTime + f;
             fov /= (1.0F - 500F / (deathTimeFov + 500F)) * 2.0F + 1.0F;
+        }
+
+        if (!isHand && sprint) {
+            fov = SprintHelper.modifyFOV(fov, f);
         }
 
         return fov;

--- a/src/main/java/net/danygames2014/unitweaks/tweaks/morekeybinds/KeyBindingListener.java
+++ b/src/main/java/net/danygames2014/unitweaks/tweaks/morekeybinds/KeyBindingListener.java
@@ -32,7 +32,7 @@ public class KeyBindingListener {
     @EventListener
     public void registerKeyBindings(KeyBindingRegisterEvent event) {
         event.keyBindings.add(dismount = new KeyBinding("key.unitweaks.dismount", Keyboard.KEY_LSHIFT));
-        event.keyBindings.add(zoom = new KeyBinding("key.unitweaks.zoom", Keyboard.KEY_LCONTROL));
+        event.keyBindings.add(zoom = new KeyBinding("key.unitweaks.zoom", Keyboard.KEY_C));
         event.keyBindings.add(photoMode = new KeyBinding("key.unitweaks.photo_mode", Keyboard.KEY_P));
         event.keyBindings.add(hideHUD = new KeyBinding("key.unitweaks.hide_hud", Keyboard.KEY_F1));
         event.keyBindings.add(takeScreenshot = new KeyBinding("key.unitweaks.take_screenshot", Keyboard.KEY_F2));

--- a/src/main/java/net/danygames2014/unitweaks/util/compat/CompatEntry.java
+++ b/src/main/java/net/danygames2014/unitweaks/util/compat/CompatEntry.java
@@ -1,0 +1,12 @@
+package net.danygames2014.unitweaks.util.compat;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+
+public class CompatEntry implements ModInitializer {
+    public static boolean sprint = false;
+    @Override
+    public void onInitialize() {
+        sprint = FabricLoader.getInstance().isModLoaded("babric_sprint");
+    }
+}

--- a/src/main/java/net/danygames2014/unitweaks/util/compat/SprintHelper.java
+++ b/src/main/java/net/danygames2014/unitweaks/util/compat/SprintHelper.java
@@ -1,0 +1,11 @@
+package net.danygames2014.unitweaks.util.compat;
+
+import static com.matthewperiut.babric_sprint.BabricSprint.lastMovementFovMultiplier;
+import static com.matthewperiut.babric_sprint.BabricSprint.movementFovMultiplier;
+
+public class SprintHelper {
+    public static float modifyFOV(float input, float f) {
+        input *= lastMovementFovMultiplier + (movementFovMultiplier - lastMovementFovMultiplier) * f;
+        return input;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,9 @@
 
   "environment": "*",
   "entrypoints": {
+    "main": [
+      "net.danygames2014.unitweaks.util.compat.CompatEntry"
+    ],
     "stationapi:event_bus": [
       "net.danygames2014.unitweaks.UniTweaks",
       "net.danygames2014.unitweaks.tweaks.recipes.ModernRecipes",


### PR DESCRIPTION
Support for changing FOV when sprinting (like modern mc).
Unitweaks still works without [Babric Sprint](https://github.com/matthewperiut/babric-sprint)
Allows [Babric Sprint](https://github.com/matthewperiut/babric-sprint) to work with UniTweaks