### PR TITLE
Fix mining speed of wooden slab when a pickaxe is being used

### DIFF
--- a/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
+++ b/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
@@ -34,10 +34,10 @@ public class MiningListener {
         int blockMeta = world.getBlockMeta(pos.x, pos.y, pos.z);
 
         // If the ID and Meta matches, true
-        if(blockMeta == 2 && blockId == Block.SLAB.id){
+        if (blockMeta == 2 && blockId == Block.SLAB.id) {
             event.resultProvider = () -> true;
-            
-        // If it doesnt, it might be last breaking tick and check the last values
+
+            // If it doesnt, it might be last breaking tick and check the last values
         } else if (blockMeta == 0 && blockId == 0) {
             // If in the last tick it matched, true
             if (lastBlockMeta == 2 && lastBlockId == Block.SLAB.id) {
@@ -62,13 +62,10 @@ public class MiningListener {
         BlockView world = event.blockView;
 
         // If the ID and Meta matches, true
-        if (  world.getBlockMeta(pos.x, pos.y, pos.z) == 2
-           && world.getBlockId(pos.x, pos.y, pos.z) == Block.SLAB.id
-           && null != event.player.inventory.getSelectedItem()
-        ) {
-            if(event.player.inventory.getSelectedItem().getItem() instanceof AxeItem axe){
+        if (world.getBlockMeta(pos.x, pos.y, pos.z) == 2 && world.getBlockId(pos.x, pos.y, pos.z) == Block.SLAB.id && event.player.inventory.getSelectedItem() != null) {
+            if (event.player.inventory.getSelectedItem().getItem() instanceof AxeItem axe) {
                 event.resultProvider = () -> axe.miningSpeed;
-            } else if (event.player.inventory.getSelectedItem().getItem() instanceof PickaxeItem pickaxe) {
+            } else if (event.player.inventory.getSelectedItem().getItem() instanceof PickaxeItem) {
                 event.resultProvider = () -> 1.0F;
             }
         }

--- a/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
+++ b/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
@@ -62,7 +62,10 @@ public class MiningListener {
         BlockView world = event.blockView;
 
         // If the ID and Meta matches, true
-        if(world.getBlockMeta(pos.x, pos.y, pos.z) == 2 && world.getBlockId(pos.x, pos.y, pos.z) == Block.SLAB.id){
+        if (  world.getBlockMeta(pos.x, pos.y, pos.z) == 2
+           && world.getBlockId(pos.x, pos.y, pos.z) == Block.SLAB.id
+           && null != event.player.inventory.getSelectedItem()
+        ) {
             if(event.player.inventory.getSelectedItem().getItem() instanceof AxeItem axe){
                 event.resultProvider = () -> axe.miningSpeed;
             } else if (event.player.inventory.getSelectedItem().getItem() instanceof PickaxeItem pickaxe) {

--- a/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
+++ b/src/main/java/net/danygames2014/unitweaks/bugfixes/slabminingfix/MiningListener.java
@@ -4,6 +4,7 @@ import net.danygames2014.unitweaks.UniTweaks;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.minecraft.block.Block;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.PickaxeItem;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import net.modificationstation.stationapi.api.event.entity.player.IsPlayerUsingEffectiveToolEvent;
@@ -64,6 +65,8 @@ public class MiningListener {
         if(world.getBlockMeta(pos.x, pos.y, pos.z) == 2 && world.getBlockId(pos.x, pos.y, pos.z) == Block.SLAB.id){
             if(event.player.inventory.getSelectedItem().getItem() instanceof AxeItem axe){
                 event.resultProvider = () -> axe.miningSpeed;
+            } else if (event.player.inventory.getSelectedItem().getItem() instanceof PickaxeItem pickaxe) {
+                event.resultProvider = () -> 1.0F;
             }
         }
     }


### PR DESCRIPTION
The pickaxes still mines the wooden slab quickly, which would be a bug when the axe is replaced as the effective item for it