### PR TITLE
fix: liquid block drop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,15 +147,17 @@
 * Sleeping Camera Rotation Fix - Fixes the sleeping camera being rotated the wrong way
 * Stairs Drop Fix - Stairs now drop themselves
 * Block Effectiveness Fix - Fixes axes and pickaxes not being effective on various blocks
-  * Axe : Crafting Table, Wooden Slab, Wooden Stairs, Fence, Wooden Door, Ladder, Sign, Pumpkin, Jack o' Latern,
-  Wooden Pressure Plate, Jukebox and Noteblock
-  * Pickaxe : Furnace, Cobblestone Stairs, Bricks, Redstone Ore, Iron Door, Rails, Dispenser, Stone Pressure Plates
-  and Spawner
+  * Axe : Crafting Table, Wooden Slab, Wooden Stairs, Fence, Wooden Door, Ladder, Sign, Pumpkin, Jack o' Lantern,
+  Wooden Pressure Plate, Jukebox, Noteblock, Trapdoor
+  * Pickaxe : Furnace, Cobblestone Stairs, Bricks, Redstone Ore, Iron Door, Rails, Dispenser, Stone Pressure Plate, 
+  Spawner, Buttons
+  * Shovel : Soul Sand
 * Pig Drop Saddle Fix - Fixes saddled pig not dropping saddle on death
 * Fence Bounding Box Fix - Fence's bounding box now better reflect its current shape
 * Pick Block Fix - Fixes some blocks not being pickable using Pick Block
 * Spring Propagation Fix - Fixes water source blocks not forming when a block below is water
-* Lava Without Source Fix - Flowing lava now correctly dissapears when source block is removed
+* Lava Without Source Fix - Flowing lava now correctly disappears when source block is removed
+* Liquid Block Drop Fix - Fixes liquid flowing down from above not dropping items such as torches and rails when broken
 * Bow Held Fix - Bows are now being held correctly and not as only items
 * Leggings Riding Fix - Fix leggings not adjusting while riding
 * ItemStack Rendering Fix - Fixes itemstacks being render below text in containers

--- a/src/main/java/net/danygames2014/unitweaks/mixin/bugfixes/liquidblockdropfix/FlowingLiquidBlockMixin.java
+++ b/src/main/java/net/danygames2014/unitweaks/mixin/bugfixes/liquidblockdropfix/FlowingLiquidBlockMixin.java
@@ -1,0 +1,45 @@
+package net.danygames2014.unitweaks.mixin.bugfixes.liquidblockdropfix;
+
+import net.danygames2014.unitweaks.UniTweaks;
+import net.minecraft.block.Block;
+import net.minecraft.block.FlowingLiquidBlock;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Random;
+
+@Mixin(FlowingLiquidBlock.class)
+public class FlowingLiquidBlockMixin {
+  /**
+   * Fixes liquid flowing down from above not dropping items such as torches and rails when broken.
+   */
+  @Inject(
+    method = "onTick",
+    at = @At(
+      value = "INVOKE",
+      // target both calls where the liquid tries to spread downwards
+      target = "Lnet/minecraft/world/World;setBlock(IIIII)Z"
+    )
+  )
+  public void preventLiquidBreakingBlocksWithoutDrops(
+    World world,
+    int x,
+    int y,
+    int z,
+    Random random,
+    CallbackInfo ci
+  ) {
+    if (!UniTweaks.BUGFIXES_CONFIG.liquidBlockDropFix) {
+      return;
+    }
+
+    var id = world.getBlockId(x, y - 1, z);
+    if (id == 0) return;
+
+    var block = Block.BLOCKS[id];
+    block.dropStacks(world, x, y - 1, z, world.getBlockMeta(x, y - 1, z));
+  }
+}

--- a/src/main/java/net/danygames2014/unitweaks/util/Config.java
+++ b/src/main/java/net/danygames2014/unitweaks/util/Config.java
@@ -320,6 +320,10 @@ public class Config {
         @ConfigEntry(name = "Lava Without Source Fix", description = "Fixes lava not dissapearing without a source block", multiplayerSynced = true)
         public Boolean lavaWithoutSourceFix = true;
 
+        @ValueOnVanillaServer(booleanValue = TriBoolean.FALSE)
+        @ConfigEntry(name = "Liquid Block Drop Fix", description = "Fixes liquid flowing down from above not dropping items such as torches and rails when broken", multiplayerSynced = true)
+        public Boolean liquidBlockDropFix = true;
+
         @ConfigEntry(name = "Bow Held Fix", description = "Skeletons and Players now hold bows properly")
         public Boolean bowHeldFix = true;
 

--- a/src/main/resources/unitweaks.mixins.json
+++ b/src/main/resources/unitweaks.mixins.json
@@ -14,6 +14,7 @@
     "bugfixes.fishvelocityfix.FishingBobberEntityMixin",
     "bugfixes.furnaceconsumebucketfix.FurnaceBlockEntityMixin",
     "bugfixes.lavawithoutsourcefix.FlowingLiquidBlockMixin",
+    "bugfixes.liquidblockdropfix.FlowingLiquidBlockMixin",
     "bugfixes.mpentityphysicsfix.EntityMixin",
     "bugfixes.nightmarepathfindingfix.NaturalSpawnerMixin",
     "bugfixes.pigdropsaddlefix.PigEntityMixin",


### PR DESCRIPTION
Fixes a vanilla bug where water flowing *directly* from above would destroy non-solid blocks (such as rails and torches) without dropping any items, compared to the behaviour when flowing from the side where it *does* drop items.

The bug and the fix can be demonstrated with a setup like this:

<img width="854" height="480" alt="2026-04-02_04 23 39" src="https://github.com/user-attachments/assets/a90bd3fb-e95b-46a2-bd34-6d645583db89" />
<img width="854" height="480" alt="2026-04-02_04 23 41" src="https://github.com/user-attachments/assets/7271d0d1-9df3-4783-9fd1-6d683d20d89c" />

In vanilla, the rail in front drops an item, but the rail at the back does not.

I've tested this with rails, torches, and snow (which should not drop anything), but happy to test with any other blocks if necessary. Also happy to adjust the config text.

Also, this is out of scope, but I also updated the Block Effectiveness Fix description in the README. Happy to split this into a separate PR if you'd like.