### PR TITLE
Photo Mode rotation wraps around to 0 rather than continuing to 200/-200

### DIFF
--- a/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/photomode/GameRendererMixin.java
+++ b/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/photomode/GameRendererMixin.java
@@ -104,12 +104,9 @@ public class GameRendererMixin {
                     (double) this.viewDistance * 4.0
             );
 
-
-
             GL11.glRotatef(photoScreen.tilt, 1.0F, 0.0F, 0.0F);
 
 //            GL11.glTranslated(xTranslation, -yTranslation, 0.0D);
-
             GL11.glRotatef(45.0F + 90.0F * photoScreen.rotation, 0.0F, 1.0F, 0.0F);
 //            GL11.glTranslated(-xTranslation, yTranslation, 0.0D);
         }

--- a/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/photomode/GameRendererMixin.java
+++ b/src/main/java/net/danygames2014/unitweaks/mixin/tweaks/photomode/GameRendererMixin.java
@@ -104,9 +104,12 @@ public class GameRendererMixin {
                     (double) this.viewDistance * 4.0
             );
 
+
+
             GL11.glRotatef(photoScreen.tilt, 1.0F, 0.0F, 0.0F);
 
 //            GL11.glTranslated(xTranslation, -yTranslation, 0.0D);
+
             GL11.glRotatef(45.0F + 90.0F * photoScreen.rotation, 0.0F, 1.0F, 0.0F);
 //            GL11.glTranslated(-xTranslation, yTranslation, 0.0D);
         }

--- a/src/main/java/net/danygames2014/unitweaks/tweaks/photomode/PhotoModeScreen.java
+++ b/src/main/java/net/danygames2014/unitweaks/tweaks/photomode/PhotoModeScreen.java
@@ -276,6 +276,12 @@ public class PhotoModeScreen extends Screen {
                 this.rotation = this.rotationGoal;
             }
         }
+
+        //Makes rotation and rotationGoal wrap around back to 0 smoothly, so the 200 limit is never hit
+        if (Math.abs(this.rotation) >= 4.0f) {
+            this.rotation = this.rotation % 4;
+            this.rotationGoal = this.rotationGoal % 4;
+        }
         if (this.tilt != this.tiltGoal) {
             this.tilt += (this.tiltGoal - this.tilt) * 0.02f + (this.tiltGoal - this.tilt) * 0.02f * delta;
             if (Math.abs(this.tilt - this.tiltGoal) < 0.01f) {


### PR DESCRIPTION
PhotoMode no longer will stop a user from rotating if rotation goal reaches 200, instead rotation and rotation goal will wrap back around to 0 after rotation goes past 4.0/-4.0