### PR TITLE
First Person Riding Hand Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,4 @@
 * Torch Bottom Texture Fix - Fixes torches not having a bottom textures
 * Slab Crash Fix - Fixes slabs with no name crashing the game
 * Block Entity Loading Fix - Stops the game from erasing an entire chunk when block entity fails to load
+* First Person Riding Hand Fix - Fixes the player's hand being misplaced when riding and using F5

--- a/src/main/java/net/danygames2014/unitweaks/mixin/bugfixes/firstpersonridinghandfix/PlayerEntityRendererMixin.java
+++ b/src/main/java/net/danygames2014/unitweaks/mixin/bugfixes/firstpersonridinghandfix/PlayerEntityRendererMixin.java
@@ -1,0 +1,26 @@
+package net.danygames2014.unitweaks.mixin.bugfixes.firstpersonridinghandfix;
+
+import net.danygames2014.unitweaks.UniTweaks;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerEntityRenderer.class)
+public class PlayerEntityRendererMixin {
+
+    @Shadow
+    private BipedEntityModel bipedModel;
+
+    @Inject(
+            method = "renderHand",
+            at = @At("TAIL")
+    )
+    private void fixFirstPersonHand(CallbackInfo ci) {
+        if (!UniTweaks.BUGFIXES_CONFIG.firstPersonRidingHandFix) return;
+        bipedModel.riding = false; // Fixes MC-1349
+    }
+}

--- a/src/main/java/net/danygames2014/unitweaks/util/Config.java
+++ b/src/main/java/net/danygames2014/unitweaks/util/Config.java
@@ -382,6 +382,9 @@ public class Config {
 
         @ConfigEntry(name = "Torch Bottom Face Fix", description = "Fixes torches not having bottom faces rendered")
         public Boolean torchBottomFaceFix = true;
+
+        @ConfigEntry(name = "First Person Riding Hand Fix", description = "Fixes the first-person hand model staying in the riding pose when riding entities")
+        public Boolean firstPersonRidingHandFix = true;
     }
 
     public static class OldFeaturesConfig {

--- a/src/main/java/net/danygames2014/unitweaks/util/Config.java
+++ b/src/main/java/net/danygames2014/unitweaks/util/Config.java
@@ -383,7 +383,7 @@ public class Config {
         @ConfigEntry(name = "Torch Bottom Face Fix", description = "Fixes torches not having bottom faces rendered")
         public Boolean torchBottomFaceFix = true;
 
-        @ConfigEntry(name = "First Person Riding Hand Fix", description = "Fixes the first-person hand model staying in the riding pose when riding entities")
+        @ConfigEntry(name = "First Person Riding Hand Fix", description = "Fixes the player's hand being misplaced when riding and using F5")
         public Boolean firstPersonRidingHandFix = true;
     }
 

--- a/src/main/resources/unitweaks.mixins.json
+++ b/src/main/resources/unitweaks.mixins.json
@@ -98,6 +98,7 @@
     "bugfixes.droppeditemfix.ItemRendererMixin",
     "bugfixes.fenceboundingboxfix.BlockRenderManagerMixin",
     "bugfixes.fencelightingfix.BlockRenderManagerMixin",
+    "bugfixes.firstpersonridinghandfix.PlayerEntityRendererMixin",
     "bugfixes.fullscreencursorfix.MouseMixin",
     "bugfixes.grassblockitemfix.BlockMixin",
     "bugfixes.grassblockitemfix.BlockRenderManagerMixin",


### PR DESCRIPTION
Fixes the player's hand being misplaced when riding and using F5 ([MC-1349](https://bugs.mojang.com/browse/MC/issues/MC-1349))